### PR TITLE
update to ESP-IDF 4.2.5, fix timing of ILI9341 initialization

### DIFF
--- a/components/OpenTyrian/episodes.c
+++ b/components/OpenTyrian/episodes.c
@@ -41,7 +41,7 @@ EXT_RAM_ATTR JE_EnemyDatType enemyDat;
 /* EPISODE variables */
 JE_byte    initial_episode_num, episodeNum = 0;
 JE_boolean episodeAvail[EPISODE_MAX]; /* [1..episodemax] */
-char       episode_file[13], cube_file[13];
+char       episode_file[22], cube_file[22];
 
 JE_longint episode1DataLoc;
 
@@ -270,7 +270,7 @@ void JE_scanForEpisodes( void )
 {
 	for (int i = 0; i < EPISODE_MAX; ++i)
 	{
-		char ep_file[20];
+		char ep_file[22];
 		snprintf(ep_file, sizeof(ep_file), "tyrian%d.lvl", i + 1);
 		episodeAvail[i] = dir_file_exists(data_dir(), ep_file);
 	}

--- a/components/OpenTyrian/episodes.h
+++ b/components/OpenTyrian/episodes.h
@@ -163,7 +163,7 @@ EXT_RAM_ATTR extern JE_EnemyDatType enemyDat;
 extern JE_byte initial_episode_num, episodeNum;
 extern JE_boolean episodeAvail[EPISODE_MAX];
 
-extern char episode_file[13], cube_file[13];
+extern char episode_file[22], cube_file[22];
 
 extern JE_longint episode1DataLoc;
 extern JE_boolean bonusLevel;

--- a/components/OpenTyrian/game_menu.c
+++ b/components/OpenTyrian/game_menu.c
@@ -850,7 +850,7 @@ void JE_itemScreen( void )
 					                   ? 100
 					                   : (yLoc * 100) / ((cube[currentCube].last_line - 9) * 12);
 
-					char buf[20];
+					char buf[50];
 					snprintf(buf, sizeof(buf), "%s %d%%", miscText[11], percent_read);
 					JE_outTextAndDarken(VGAScreen, 176, 160, buf, 14, 1, TINY_FONT);
 

--- a/components/OpenTyrian/joystick.c
+++ b/components/OpenTyrian/joystick.c
@@ -44,8 +44,8 @@ bool ignore_joystick = false;
 int joysticks = 0;
 Joystick *joystick = NULL;
 
-static const char joystick_cfg_version = 1;
-static const int joystick_analog_max = 32767;
+// static const char joystick_cfg_version = 1;
+// static const int joystick_analog_max = 32767;
 
 // eliminates axis movement below the threshold
 int joystick_axis_threshold( int j, int value )
@@ -109,19 +109,19 @@ void reset_joystick_assignments( int j )
 {
 }
 
-static const char* const assignment_names[] =
-{
-	"up",
-	"right",
-	"down",
-	"left",
-	"fire",
-	"change fire",
-	"left sidekick",
-	"right sidekick",
-	"menu",
-	"pause",
-};
+// static const char* const assignment_names[] =
+// {
+// 	"up",
+// 	"right",
+// 	"down",
+// 	"left",
+// 	"fire",
+// 	"change fire",
+// 	"left sidekick",
+// 	"right sidekick",
+// 	"menu",
+// 	"pause",
+// };
 
 bool load_joystick_assignments( Config *config, int j )
 {

--- a/components/OpenTyrian/lvllib.c
+++ b/components/OpenTyrian/lvllib.c
@@ -22,7 +22,7 @@
 
 JE_LvlPosType lvlPos;
 
-char levelFile[13]; /* string [12] */
+char levelFile[22]; /* string [12] */
 JE_word lvlNum;
 
 void JE_analyzeLevel( void )

--- a/components/OpenTyrian/lvllib.h
+++ b/components/OpenTyrian/lvllib.h
@@ -25,7 +25,7 @@
 typedef JE_longint JE_LvlPosType[43]; /* [1..42 + 1] */
 
 extern JE_LvlPosType lvlPos;
-extern char levelFile[13]; /* string [12] */
+extern char levelFile[22]; /* string [12] */
 extern JE_word lvlNum;
 
 void JE_analyzeLevel( void );

--- a/components/OpenTyrian/tyrian2.c
+++ b/components/OpenTyrian/tyrian2.c
@@ -70,7 +70,7 @@ JE_word levelEnemyMax;
 JE_word levelEnemyFrequency;
 JE_word levelEnemy[40]; /* [1..40] */
 
-char tempStr[31];
+char tempStr[50];
 
 /* Data used for ItemScreen procedure to indicate items available */
 JE_byte itemAvail[9][10]; /* [1..9, 1..10] */
@@ -2096,28 +2096,6 @@ draw_player_shot_loop_end:
 	tempX = mouse_x;
 	tempY = mouse_y;
 
-	if (debug)
-	{
-		strcpy(tempStr, "");
-		for (temp = 0; temp < 9; temp++)
-		{
-			sprintf(tempStr, "%s%c", tempStr,  smoothies[temp] + 48);
-		}
-		sprintf(buffer, "SM = %s", tempStr);
-		JE_outText(VGAScreen, 30, 70, buffer, 4, 0);
-
-		sprintf(buffer, "Memory left = %d", -1);
-		JE_outText(VGAScreen, 30, 80, buffer, 4, 0);
-		sprintf(buffer, "Enemies onscreen = %d", enemyOnScreen);
-		JE_outText(VGAScreen, 30, 90, buffer, 6, 0);
-
-		debugHist = debugHist + abs((JE_longint)debugTime - (JE_longint)lastDebugTime);
-		debugHistCount++;
-		sprintf(tempStr, "%2.3f", 1000.0f / roundf(debugHist / debugHistCount));
-		sprintf(buffer, "X:%d Y:%-5d  %s FPS  %d %d %d %d", (mapX - 1) * 12 + player[0].x, curLoc, tempStr, player[0].x_velocity, player[0].y_velocity, player[0].x, player[0].y);
-		JE_outText(VGAScreen, 45, 175, buffer, 15, 3);
-		lastDebugTime = debugTime;
-	}
 
 	if (displayTime > 0)
 	{

--- a/components/OpenTyrian/tyrian2.h
+++ b/components/OpenTyrian/tyrian2.h
@@ -36,7 +36,7 @@ boss_bar_t;
 
 extern boss_bar_t boss_bar[2];
 
-extern char tempStr[31];
+extern char tempStr[50];
 extern JE_byte itemAvail[9][10], itemAvailMax[9];
 
 void JE_createNewEventEnemy( JE_byte enemytypeofs, JE_word enemyoffset, Sint16 uniqueShapeTableI );

--- a/components/SDL/SDL_input.c
+++ b/components/SDL/SDL_input.c
@@ -450,7 +450,7 @@ SDL_bool SDL_ShouldIgnoreJoystick(const char *name, SDL_JoystickGUID guid)
 /* return the guid for this index */
 SDL_JoystickGUID SDL_JoystickGetDeviceGUID(int device_index)
 {
-    SDL_JoystickGUID guid;
+    SDL_JoystickGUID guid = {{0}};
     return guid;
 }
 
@@ -492,7 +492,7 @@ int SDL_JoystickGetDeviceIndexFromInstanceID(SDL_JoystickID instance_id)
 
 SDL_JoystickGUID SDL_JoystickGetGUID(SDL_Joystick * joystick)
 {
-    SDL_JoystickGUID guid;
+    SDL_JoystickGUID guid = {{0}};
     return guid;
 }
 
@@ -552,7 +552,7 @@ static unsigned char nibble(char c)
 /* convert the string version of a joystick guid to the struct */
 SDL_JoystickGUID SDL_JoystickGetGUIDFromString(const char *pchGUID)
 {
-    SDL_JoystickGUID guid;
+    SDL_JoystickGUID guid = {{0}};
     return guid;
 }
 

--- a/components/SDL/SDL_system.c
+++ b/components/SDL/SDL_system.c
@@ -40,7 +40,7 @@ void SDL_Quit(void)
 void SDL_InitSD(void)
 {
     printf("Initialising SD Card\n");
-#if 1
+#if 0
 	sdmmc_host_t host = SDSPI_HOST_DEFAULT();
     host.command_timeout_ms = 3000;
     host.max_freq_khz = SDMMC_FREQ_DEFAULT;


### PR DESCRIPTION
This is small refresh of the code, so the app is buildable with ESP-IDF 4.2.5.

There are some compiler checks on overflow, basically solved by increasing sprintf buffers.

The more problematic issue was the display initialization of ESP Wroverkit, since Wroverkit has integrated display, the initialization delays must be kept according to spec. Otherwise there is just blank screen.
I've updated the driver initialization based on this driver: https://github.com/almindor/mipidsi/blob/master/mipidsi/src/models/ili934x.rs#L29

Also Wrover Kit has connected SD card using SDIO, so I had to enable hardcoded define in the code which was using SPI, It would be nice to pull it into menuconfig. This could be done together with updating to newer ESP-IDF 5.3 and using [ESP-BSP](https://github.com/espressif/esp-bsp), so that the app is working on multiple boards.

@jkirsons This is really nice project, I would love to hear your ideas and feedback. I appreciate the idea of using SDL layer.

@espzav Thanks for consultation about ESP-BSP.